### PR TITLE
Resolve base type fields in `[](TAny, string)`

### DIFF
--- a/lib/core/typeinfo.nim
+++ b/lib/core/typeinfo.nim
@@ -339,6 +339,8 @@ proc `[]`*(x: TAny, fieldName: string): TAny =
   if n != nil:
     result.value = x.value +!! n.offset
     result.rawType = n.typ
+  elif x.rawType.kind == tyObject and x.rawType.base != nil:
+    return `[]`(TAny(value: x.value, rawType: x.rawType.base), fieldName)
   else:
     raise newException(ValueError, "invalid field name: " & fieldName)
 


### PR DESCRIPTION
I found when using `marshal` that it would blow up if you tried to unmarshal fields that are defined on a parent object.

Example:

``` nim
import marshal
import streams

type
  A {.inheritable.} = object
    a*: int

  B = object of A
    b*: int

var b = B()
load[B](newStringStream("""{"a": 1, "b": 2}"""), b)
echo($$(b))
```

This change fixes the above example, but I've no idea if this will interact terribly with other things in the compiler.
